### PR TITLE
removed hardhat-deploy due to compilation issue

### DIFF
--- a/deploy/deploy.ts
+++ b/deploy/deploy.ts
@@ -1,11 +1,10 @@
-import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
 const DAY_IN_SECONDS = 60 * 60 * 24;
 const NOW_IN_SECONDS = Math.round(Date.now() / 1000);
 const UNLOCK_IN_X_DAYS = NOW_IN_SECONDS + DAY_IN_SECONDS * 1; // 1 DAY
 
-const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+const func = async function (hre: HardhatRuntimeEnvironment) {
   const { deployer } = await hre.getNamedAccounts();
   const { deploy } = hre.deployments;
   const lockedAmount = hre.ethers.parseEther("0.01").toString();

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,5 +1,4 @@
 import "@nomicfoundation/hardhat-toolbox";
-import "hardhat-deploy";
 import type { HardhatUserConfig } from "hardhat/config";
 import { vars } from "hardhat/config";
 import type { NetworkUserConfig } from "hardhat/types";

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "ethers": "^6.9.0",
     "fs-extra": "^11.2.0",
     "hardhat": "^2.19.2",
-    "hardhat-deploy": "^0.11.45",
     "hardhat-gas-reporter": "^1.0.9",
     "lodash": "^4.17.21",
     "mocha": "^10.2.0",


### PR DESCRIPTION
Fixes https://github.com/PaulRBerg/hardhat-template/issues/186

But removes hardhat-deploy plugin, and thus breaks deployment scripts. Feel free to repurpose.

Might be resolved anyway by upstream PR on hardhat-deploy https://github.com/wighawag/hardhat-deploy/pull/511

@PaulRBerg it's up to you what you want to do, but I suggest removing hardhat-deploy support for now