### PR TITLE
Fix README to use Hardhat config vars instead of .env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ ganache -s test
 
 > The `-s test` passes a seed to the local chain and makes it deterministic
 
-Make sure to set the mnemonic in your `.env` file to that of the instance running with Ganache.
+Make sure to set the mnemonic using `bunx hardhat vars set MNEMONIC` to that of the instance running with Ganache.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Fixed inconsistent documentation in the Ganache section of README.md
- The README previously instructed users to set the mnemonic in a `.env` file, but this template uses Hardhat Configuration Variables
- Updated the instruction to use `bunx hardhat vars set MNEMONIC` instead, which is consistent with the rest of the documentation

## Test plan
- [x] Documentation-only change
- [x] Verified this matches the approach documented in the "Pre Requisites" section